### PR TITLE
add rclone to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,8 @@ RUN yum install -y vim-enhanced nano emacs \
     texlive texlive-cm-super texlive-dvipng texlive-dvipng-bin \
     MariaDB-client MariaDB-devel MariaDB-connect-engine
 
+RUN curl https://rclone.org/install.sh | bash
+
 USER $NB_UID
 
 # upgrade all conda packages

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,18 +8,27 @@ COPY install_cdms_kernels /usr/local/bin/
 
 USER root
 
-RUN yum install -y vim-enhanced nano emacs texlive texlive-cm-super texlive-dvipng texlive-dvipng-bin
+RUN echo $'[mariadb] \n\
+name = MariaDB \n\
+baseurl = http://yum.mariadb.org/10.3/centos7-amd64 \n\
+gpgkey=https://yum.mariadb.org/RPM-GPG-KEY-MariaDB \n\
+gpgcheck=1 ' >> /etc/yum.repos.d/MariaDB.repo
+
+RUN yum install -y vim-enhanced nano emacs \
+    texlive texlive-cm-super texlive-dvipng texlive-dvipng-bin \
+    MariaDB-client MariaDB-devel MariaDB-connect-engine
 
 USER $NB_UID
 
-# install conda packages and jupyter lab extensions
+# upgrade all conda packages
 
-RUN conda upgrade --quiet --yes 'jupyterlab' ipympl ipywidgets && \
+RUN conda upgrade --quiet --yes --all && \
     conda install --quiet --yes \
     'jupyterlab-system-monitor' \
-    && \
     conda clean --all -f -y && \
     rm -rf "/home/${NB_USER}/.cache/yarn" && \
     rm -rf "/home/${NB_USER}/.node-gyp" && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"
+
+RUN pip install mariadb sqlalchemy


### PR DESCRIPTION
Add rclone to Dockerfile with the one-line install command from https://rclone.org/install/.