### PR TITLE
update README to include info on building, testing, pushing container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ USER $NB_UID
 
 RUN conda upgrade --quiet --yes --all && \
     conda install --quiet --yes \
-    'jupyterlab-system-monitor' \
+    'jupyterlab-system-monitor' && \
     conda clean --all -f -y && \
     rm -rf "/home/${NB_USER}/.cache/yarn" && \
     rm -rf "/home/${NB_USER}/.node-gyp" && \

--- a/Makefile
+++ b/Makefile
@@ -2,4 +2,7 @@ build:
 	docker build -t zonca/docker-jupyter-cdms-light:${VERSION} .
 
 push:
-	docker push zonca/docker-jupyter-cdms-light:${VERSION}
+	docker login && docker push zonca/docker-jupyter-cdms-light:${VERSION}
+
+shell:
+	docker run -it zonca/docker-jupyter-cdms-light:${VERSION} bash

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,11 @@
 build:
 	docker build -t zonca/docker-jupyter-cdms-light:${VERSION} .
 
+login:
+	docker login
+
 push:
-	docker login && docker push zonca/docker-jupyter-cdms-light:${VERSION}
+	docker push zonca/docker-jupyter-cdms-light:${VERSION}
 
 shell:
 	docker run -it zonca/docker-jupyter-cdms-light:${VERSION} bash

--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,6 @@ push:
 
 shell:
 	docker run -it zonca/docker-jupyter-cdms-light:${VERSION} bash
+
+tag:
+	git tag -a ${VERSION} -m "Tag ${VERSION} in Github repository"

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The `Makefile` in this directory provides useful docker commands.  All commands 
 
 * `make build` builds a container from the Dockerfile
 * `make shell` will drop you into an image shell; useful if you want to check anything before pushing
-* `make push` uploads the container to https://hub.docker.com/r/zonca/docker-jupyter-cdms-light.  For this command to work you will need access to this dockerhub project - get a dockerhub account if you don't already have one and request the maintainer of this repository for access. 
+* `make push` uploads the container to https://hub.docker.com/r/zonca/docker-jupyter-cdms-light.  For this command to work you will need access to this dockerhub project - get a dockerhub account if you don't already have one and request access from the maintainer of this repository.  You can `make login` if you are not already authenticated to dockerhub. 
 
 ## Deploy in production
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ The `Makefile` in this directory provides useful docker commands.  All commands 
 * `make shell` will drop you into an image shell; useful if you want to check anything before pushing
 * `make push` uploads the container to [dockerhub](https://hub.docker.com/r/zonca/docker-jupyter-cdms-light).  For this command to work you will need access to this dockerhub project - get a dockerhub account if you don't already have one and request access from the maintainer of this repository.  You can `make login` if you are not already authenticated to dockerhub. 
 
+If your shell supports tab completion, `make` <kbd>space</kbd><kbd>tab</kbd><kbd>tab</kbd> will show all available commands (or "targets" in make-language).  You can also open `Makefile` in a text editor to see available targets.
+
 ## Deploy in production
 
 The version of the image used in production is defined in `config_standard_storage.yaml`:

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Generally we update a few times a year and we do 3/4 releases the same day, so l
 
 See <https://calver.org/>
 
-## Image build on DockerHub (stopped working)
+## Image build
 
 This is setup [on DockerHub](https://hub.docker.com/r/zonca/docker-jupyter-cdms-light)
 
@@ -41,7 +41,7 @@ The `Makefile` in this directory provides useful docker commands.  All commands 
 
 * `make build` builds a container from the Dockerfile
 * `make shell` will drop you into an image shell; useful if you want to check anything before pushing
-* `make push` uploads the container to https://hub.docker.com/r/zonca/docker-jupyter-cdms-light.  For this command to work you will (1) need access to this dockerhub project and (2) need to authenticate to dockerhub.push it to Dockerhub.  
+* `make push` uploads the container to https://hub.docker.com/r/zonca/docker-jupyter-cdms-light.  For this command to work you will (1) need access to this dockerhub project and (2) need to authenticate to dockerhub. 
 
 ## Deploy in production
 

--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ Generally we update a few times a year and we do 3/4 releases the same day, so l
 
 See <https://calver.org/>
 
+Better to not use `latest` in production, always make a tag and use that.  See [the Image build section](#image-build) for instructions on how to do this.
+
 ## Image build
 
-This is setup [on DockerHub](https://hub.docker.com/r/zonca/docker-jupyter-cdms-light)
-
-Better not use `latest` in production, always make a tag and use that.
+The container is hosted [on DockerHub](https://hub.docker.com/r/zonca/docker-jupyter-cdms-light)
 
 Unfortunately [Docker stopped providing free autobuilds](https://www.docker.com/blog/changes-to-docker-hub-autobuilds),
 so now we need to build a new image on a machine with Docker and then push to Dockerhub.
@@ -41,7 +41,7 @@ The `Makefile` in this directory provides useful docker commands.  All commands 
 
 * `make build` builds a container from the Dockerfile
 * `make shell` will drop you into an image shell; useful if you want to check anything before pushing
-* `make push` uploads the container to https://hub.docker.com/r/zonca/docker-jupyter-cdms-light.  For this command to work you will need access to this dockerhub project - get a dockerhub account if you don't already have one and request access from the maintainer of this repository.  You can `make login` if you are not already authenticated to dockerhub. 
+* `make push` uploads the container to [dockerhub](https://hub.docker.com/r/zonca/docker-jupyter-cdms-light).  For this command to work you will need access to this dockerhub project - get a dockerhub account if you don't already have one and request access from the maintainer of this repository.  You can `make login` if you are not already authenticated to dockerhub. 
 
 ## Deploy in production
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,16 @@ Better not use `latest` in production, always make a tag and use that.
 Unfortunately [Docker stopped providing free autobuilds](https://www.docker.com/blog/changes-to-docker-hub-autobuilds),
 so now we need to build a new image on a machine with Docker and then push to Dockerhub.
 
+The `Makefile` in this directory provides several commands (`make build` and `make push`) that build an image and push it to Dockerhub.  The file assumes (1) that you set a `VERSION` environment variable and (2) that you can run `docker` without `sudo`, see (the Docker documentation)[https://docs.docker.com/engine/install/linux-postinstall/] if you need to set this up.
+
+You can check your container before pushing it with:
+
+```
+docker run -it zonca/docker-jupyter-cdms-light:<version>
+docker ps #this output will tell you the image name
+docker exec -it <container_name> bash
+```
+
 ## Deploy in production
 
 The version of the image used in production is defined in `config_standard_storage.yaml`:

--- a/README.md
+++ b/README.md
@@ -30,23 +30,18 @@ See <https://calver.org/>
 
 ## Image build on DockerHub (stopped working)
 
-This is setup with [autobuild on DockerHub](https://hub.docker.com/r/zonca/docker-jupyter-cdms-light)
-It automatically builds `master` as `latest` and it builds all the tags.
+This is setup [on DockerHub](https://hub.docker.com/r/zonca/docker-jupyter-cdms-light)
 
 Better not use `latest` in production, always make a tag and use that.
 
 Unfortunately [Docker stopped providing free autobuilds](https://www.docker.com/blog/changes-to-docker-hub-autobuilds),
 so now we need to build a new image on a machine with Docker and then push to Dockerhub.
 
-The `Makefile` in this directory provides several commands (`make build` and `make push`) that build an image and push it to Dockerhub.  The file assumes (1) that you set a `VERSION` environment variable and (2) that you can run `docker` without `sudo`, see (the Docker documentation)[https://docs.docker.com/engine/install/linux-postinstall/] if you need to set this up.
+The `Makefile` in this directory provides useful docker commands.  All commands assume (1) that you set a `VERSION` environment variable for the tag (see [the versioning section](#Versioning)) and (2) that you can run `docker` without `sudo`.  See (the Docker documentation)[https://docs.docker.com/engine/install/linux-postinstall/] if you need to set this up.
 
-You can check your container before pushing it with:
-
-```
-docker run -it zonca/docker-jupyter-cdms-light:<version>
-docker ps #this output will tell you the image name
-docker exec -it <container_name> bash
-```
+* `make build` builds a container from the Dockerfile
+* `make shell` will drop you into an image shell; useful if you want to check anything before pushing
+* `make push` uploads the container to https://hub.docker.com/r/zonca/docker-jupyter-cdms-light.  For this command to work you will (1) need access to this dockerhub project and (2) need to authenticate to dockerhub.push it to Dockerhub.  
 
 ## Deploy in production
 

--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ Better not use `latest` in production, always make a tag and use that.
 Unfortunately [Docker stopped providing free autobuilds](https://www.docker.com/blog/changes-to-docker-hub-autobuilds),
 so now we need to build a new image on a machine with Docker and then push to Dockerhub.
 
-The `Makefile` in this directory provides useful docker commands.  All commands assume (1) that you set a `VERSION` environment variable for the tag (see [the versioning section](#Versioning)) and (2) that you can run `docker` without `sudo`.  See (the Docker documentation)[https://docs.docker.com/engine/install/linux-postinstall/] if you need to set this up.
+The `Makefile` in this directory provides useful docker commands.  All commands assume (1) that you set a `VERSION` environment variable for the tag (see [the versioning section](#Versioning)) and (2) that you can run `docker` without `sudo`.  See [the Docker documentation](https://docs.docker.com/engine/install/linux-postinstall/) if you need to set this up.
 
 * `make build` builds a container from the Dockerfile
 * `make shell` will drop you into an image shell; useful if you want to check anything before pushing
-* `make push` uploads the container to https://hub.docker.com/r/zonca/docker-jupyter-cdms-light.  For this command to work you will (1) need access to this dockerhub project and (2) need to authenticate to dockerhub. 
+* `make push` uploads the container to https://hub.docker.com/r/zonca/docker-jupyter-cdms-light.  For this command to work you will need access to this dockerhub project - get a dockerhub account if you don't already have one and request the maintainer of this repository for access. 
 
 ## Deploy in production
 


### PR DESCRIPTION
I updated the README to include information on using the Makefile commands.  Related:
* added `docker login` to the `docker push` line, not sure if this will cause issues for those already logged in?
* added a `make shell` command

Also removed out-of-date information about autobuilds (kept the explanation of autobuilds for future reference).  Goal was to make it look less like the section was marked "failed", which I initially read as "ignore me".  

Fixed an issue with the Dockerfile, two distinct commands needed a `&&` to be separated.